### PR TITLE
Don't register variables on the stack as global

### DIFF
--- a/ext/sequel_pg/sequel_pg.c
+++ b/ext/sequel_pg/sequel_pg.c
@@ -1009,7 +1009,7 @@ void Init_sequel_pg(void) {
   rb_global_variable(&spg_BigDecimal);
   rb_global_variable(&spg_Date);
   rb_global_variable(&spg_SQLTime);
-  rb_global_variable(&spg_Postgres);
+  rb_global_variable(&spg_PGError);
   rb_global_variable(&spg_nan);
   rb_global_variable(&spg_pos_inf);
   rb_global_variable(&spg_neg_inf);


### PR DESCRIPTION
By definition, VALUE pointers on the stack can never be a global variable.
The location goes out of scope when the function is executed and
can point at random data.

On the other hand, the error class is used as global so mark it as such.
