### PR TITLE
Fix installation on Mac OS with Intel chips

### DIFF
--- a/ext/sequel_pg/extconf.rb
+++ b/ext/sequel_pg/extconf.rb
@@ -2,7 +2,7 @@ require 'mkmf'
 $CFLAGS << " -O0 -g" if ENV['DEBUG']
 $CFLAGS << " -Drb_tainted_str_new=rb_str_new -DNO_TAINT" if RUBY_VERSION >= '2.7'
 $CFLAGS << " -Wall " unless RUBY_PLATFORM =~ /solaris/
-$LDFLAGS += " -Wl,-U,_pg_get_pgconn -Wl,-U,_pg_get_result_enc_idx -Wl,-U,_pgresult_get -Wl,-U,_pgresult_stream_any " if RUBY_PLATFORM =~ /arm64-darwin/
+$LDFLAGS += " -Wl,-U,_pg_get_pgconn -Wl,-U,_pg_get_result_enc_idx -Wl,-U,_pgresult_get -Wl,-U,_pgresult_stream_any " if RUBY_PLATFORM =~ /darwin/
 dir_config('pg', ENV["POSTGRES_INCLUDE"] || (IO.popen("pg_config --includedir").readline.chomp rescue nil),
                  ENV["POSTGRES_LIB"]     || (IO.popen("pg_config --libdir").readline.chomp rescue nil))
 


### PR DESCRIPTION
Starting from Mac OS Ventura (13) I was not able to install sequel_pg gem anymore. Some LDFLAGS were missing.

A fix was already present for ARM chips, but not for Intel chips. I've edited the regular expression to match both architectures.