### PR TITLE
Cancel in-progress query before draining results on streaming interrupt

### DIFF
--- a/ext/sequel_pg/extconf.rb
+++ b/ext/sequel_pg/extconf.rb
@@ -10,6 +10,7 @@ if (have_library('pq') || have_library('libpq') || have_library('ms/libpq')) && 
   have_func 'rb_hash_new_capa'
   have_func 'rb_set_new_capa'
   have_func 'PQsetSingleRowMode'
+  have_func 'PQgetCancel'
   have_func 'timegm'
   create_makefile("sequel_pg")
 else

--- a/ext/sequel_pg/sequel_pg.c
+++ b/ext/sequel_pg/sequel_pg.c
@@ -2004,6 +2004,33 @@ static VALUE spg__flush_results(VALUE rconn) {
   VALUE error = 0;
   conn = pg_get_pgconn(rconn);
 
+#ifdef HAVE_PQGETCANCEL
+  /* Only cancel if an exception is being unwound. During normal
+   * completion, the query has already finished and there are no
+   * results to drain, so canceling is unnecessary. */
+  if (rb_errinfo() != Qnil) {
+    PGcancel *cancel = PQgetCancel(conn);
+    if (cancel) {
+      char errbuf[256];
+      int cancel_ok = PQcancel(cancel, errbuf, sizeof(errbuf));
+      PQfreeCancel(cancel);
+
+      if (cancel_ok) {
+        /* Cancel succeeded. Drain remaining results without raising.
+         * The cancel produces an expected error result ("canceling
+         * statement due to user request"). The original exception
+         * will propagate via rb_ensure. */
+        while ((res = PQgetResult(conn)) != NULL) {
+          PQclear(res);
+        }
+        return rconn;
+      }
+      /* Cancel failed — fall through to the normal drain loop which
+       * will check for and report any real errors. */
+    }
+  }
+#endif
+
   while ((res = PQgetResult(conn)) != NULL) {
     if (!error) {
       switch (PQresultStatus(res))
@@ -2019,7 +2046,7 @@ static VALUE spg__flush_results(VALUE rconn) {
     }
     PQclear(res);
   }
-  
+
   if (error) {
     VALUE exception = rb_exc_new3(spg_PGError, error);
     rb_iv_set(exception, "@connection", rconn);

--- a/spec/sequel_pg_spec.rb
+++ b/spec/sequel_pg_spec.rb
@@ -73,4 +73,99 @@ describe 'sequel_pg' do
 
     db.drop_table(:streaming_cancel_test)
   end
+
+  it "should clean up quickly when streaming a large result set is interrupted" do
+    db.drop_table?(:streaming_large_test)
+    db.create_table(:streaming_large_test) do
+      primary_key :id
+      String :data, size: 200
+    end
+
+    # 100,000 rows with non-trivial data
+    100.times do
+      db.run("INSERT INTO streaming_large_test (data) SELECT repeat(md5(random()::text), 6) FROM generate_series(1, 1000)")
+    end
+
+    rows_read = 0
+    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+    begin
+      db[:streaming_large_test].stream.each do |row|
+        rows_read += 1
+        raise "stop" if rows_read >= 10
+      end
+    rescue RuntimeError
+      # expected
+    end
+
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
+
+    # Without cancel, draining 99,990 remaining rows takes noticeable time.
+    # With cancel, cleanup should be nearly instant.
+    elapsed.must_be :<, 2.0
+
+    # Connection must still be healthy
+    db[:streaming_large_test].count.must_equal 100000
+
+    # Can stream again successfully
+    second_rows = []
+    db[:streaming_large_test].limit(3).stream.each { |r| second_rows << r }
+    second_rows.length.must_equal 3
+
+    db.drop_table(:streaming_large_test)
+  end
+
+  it "should stream all rows correctly when not interrupted" do
+    db.drop_table?(:streaming_normal_test)
+    db.create_table(:streaming_normal_test) do
+      primary_key :id
+      Integer :value
+    end
+
+    db.run("INSERT INTO streaming_normal_test (value) SELECT g FROM generate_series(1, 500) g")
+
+    rows = []
+    db[:streaming_normal_test].order(:id).stream.each do |row|
+      rows << row[:value]
+    end
+
+    rows.length.must_equal 500
+    rows.first.must_equal 1
+    rows.last.must_equal 500
+
+    db.drop_table(:streaming_normal_test)
+  end
+
+  it "should handle multiple streaming interruptions on the same connection" do
+    db.drop_table?(:streaming_multi_test)
+    db.create_table(:streaming_multi_test) do
+      primary_key :id
+      String :data
+    end
+
+    db.run("INSERT INTO streaming_multi_test (data) SELECT md5(random()::text) FROM generate_series(1, 5000)")
+
+    # Interrupt streaming 5 times in a row
+    5.times do |attempt|
+      rows_read = 0
+      begin
+        db[:streaming_multi_test].stream.each do |row|
+          rows_read += 1
+          raise "stop #{attempt}" if rows_read >= 3
+        end
+      rescue RuntimeError
+        # expected
+      end
+    end
+
+    # Connection should still be perfectly healthy
+    db[:streaming_multi_test].count.must_equal 5000
+
+    # Full stream should still work
+    all_rows = []
+    db[:streaming_multi_test].stream.each { |r| all_rows << r }
+    all_rows.length.must_equal 5000
+
+    db.drop_table(:streaming_multi_test)
+  end
 end

--- a/spec/sequel_pg_spec.rb
+++ b/spec/sequel_pg_spec.rb
@@ -38,4 +38,39 @@ describe 'sequel_pg' do
     db.select(Sequel.as(1, :v)).stream.paged_each{|row| a << row}
     a.must_equal [{:v=>1}]
   end
+
+  it "should cancel the query when streaming is interrupted" do
+    db.drop_table?(:streaming_cancel_test)
+    db.create_table(:streaming_cancel_test) do
+      primary_key :id
+      String :data
+    end
+
+    db.run("INSERT INTO streaming_cancel_test (data) SELECT md5(random()::text) FROM generate_series(1, 10000)")
+
+    rows_read = 0
+    error_raised = false
+
+    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+    begin
+      db[:streaming_cancel_test].stream.each do |row|
+        rows_read += 1
+        raise "interrupted" if rows_read >= 5
+      end
+    rescue RuntimeError => e
+      error_raised = true if e.message == "interrupted"
+    end
+
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
+
+    error_raised.must_equal true
+    rows_read.must_equal 5
+    elapsed.must_be :<, 2.0
+
+    # Verify connection is still usable
+    db[:streaming_cancel_test].count.must_equal 10000
+
+    db.drop_table(:streaming_cancel_test)
+  end
 end


### PR DESCRIPTION
👋! 

When a streaming query is interrupted (e.g., client disconnect, exception during row iteration), `spg__flush_results` drains all remaining results from the connection by calling `PQgetResult` in a loop until it returns `NULL`. For large result sets, PostgreSQL continues producing rows that nobody will consume, and this drain can take minutes — blocking the parent thread the entire time. With enough concurrent interrupted streams, all available threads get stuck in cleanup, causing things to become unresponsive. My team has seen this in production.

The fix I put together here stops the query before the drain so it doesn't get into a position where it's just chasing rows. I added some tests as well.